### PR TITLE
Fixed "in X servers" message.

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ bot.on('guildMemberAdd', member => {
 
 //Playing Message
 bot.on("ready", async () => {
-  console.log(`${bot.user.username} is online on ${bot.guilds.size} servers!`);
+  console.log(`${bot.user.username} is online on ${bot.guilds.cache.size} servers!`);
 
   bot.user.setActivity("My Code", {type: "PLAYING"});
 });


### PR DESCRIPTION
The Client.guilds object is a GuildManager object, and trying to get it's size will return undefined. Instead, we should query Client.guilds.cache to get a Collection object, which extends Map and does have the size property. Naturally the data stored in Client.guilds.cache is cached and can be out of date by the time it's called, but in the given scenario (bot just booted up), it's unlikely to be inaccurate enough to make a difference.